### PR TITLE
fix: sanitize empty enum entries for Gemini function declarations

### DIFF
--- a/addons/claude-backend/providers/google.py
+++ b/addons/claude-backend/providers/google.py
@@ -16,6 +16,30 @@ logger = logging.getLogger(__name__)
 class GoogleProvider(EnhancedProvider):
     """Enhanced provider adapter for Google Gemini models."""
 
+    @staticmethod
+    def _sanitize_function_parameters_for_gemini(schema: Any) -> Any:
+        """Return a deep-copied schema safe for Gemini function declarations.
+
+        Gemini rejects empty-string enum values. Other providers may allow them,
+        so we sanitize only on the Google provider path.
+        """
+        import copy
+
+        node = copy.deepcopy(schema)
+
+        def _walk(value: Any) -> Any:
+            if isinstance(value, dict):
+                cleaned = {k: _walk(v) for k, v in value.items()}
+                enum_values = cleaned.get("enum")
+                if isinstance(enum_values, list):
+                    cleaned["enum"] = [v for v in enum_values if not (isinstance(v, str) and v == "")]
+                return cleaned
+            if isinstance(value, list):
+                return [_walk(v) for v in value]
+            return value
+
+        return _walk(node)
+
     def __init__(self, api_key: str = "", model: str = ""):
         """Initialize Google provider with enhanced features."""
         super().__init__(api_key, model)
@@ -127,7 +151,9 @@ class GoogleProvider(EnhancedProvider):
                 _decl = {
                     "name": _name,
                     "description": str(_fn.get("description") or ""),
-                    "parameters": _fn.get("parameters") or {"type": "object", "properties": {}},
+                    "parameters": self._sanitize_function_parameters_for_gemini(
+                        _fn.get("parameters") or {"type": "object", "properties": {}}
+                    ),
                 }
                 _decls.append(_decl)
             if _decls:

--- a/addons/claude-backend/tests/test_google_schema_sanitization.py
+++ b/addons/claude-backend/tests/test_google_schema_sanitization.py
@@ -1,0 +1,30 @@
+from providers.google import GoogleProvider
+
+
+def test_sanitize_removes_empty_enum_strings_recursively():
+    schema = {
+        "type": "object",
+        "properties": {
+            "disabled_by": {"type": "string", "enum": ["automation", ""]},
+            "nested": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["a", "", "b"]}
+                },
+            },
+        },
+    }
+
+    cleaned = GoogleProvider._sanitize_function_parameters_for_gemini(schema)
+
+    assert cleaned["properties"]["disabled_by"]["enum"] == ["automation"]
+    assert cleaned["properties"]["nested"]["properties"]["mode"]["enum"] == ["a", "b"]
+
+
+def test_sanitize_does_not_mutate_original_schema():
+    schema = {"type": "string", "enum": ["x", ""]}
+
+    cleaned = GoogleProvider._sanitize_function_parameters_for_gemini(schema)
+
+    assert schema["enum"] == ["x", ""]
+    assert cleaned["enum"] == ["x"]


### PR DESCRIPTION
## Summary
- sanitize Gemini function declaration schemas before sending them to `streamGenerateContent`
- remove empty-string enum values recursively (Gemini rejects empty enum entries)
- keep behavior provider-scoped to Google only
- add regression coverage for nested enums and non-mutating behavior

## Why
Issue #30 reports `GenerateContentRequest...enum[1]: cannot be empty` for Gemini. The root cause is empty enum entries in tool schemas (for example `disabled_by: ["...", ""]`). This patch strips only empty string enum values from the Google provider path.

## Validation
- code review of generated declaration path in `providers/google.py`
- added regression tests in `tests/test_google_schema_sanitization.py`

Closes #30

Greetings, saschabuehrle
